### PR TITLE
Expand m68040 support

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -500,7 +500,7 @@ class FP_OpRegisterMovemList:
                     last_reg = i
                     tokens.append(InstructionTextToken(
                         InstructionTextTokenType.RegisterToken, FP_Registers[i]))
-                elif last_reg is i-1:
+                elif last_reg == i-1:
                     seq = True
                     last_reg = i
                 else:
@@ -2233,7 +2233,7 @@ class M68000(Architecture):
                         if extra_dest is not None:
                             length += extra_dest
 
-                    elif (sub_fp_operation_code & 0x6) == 4:
+                    elif (sub_fp_operation_code & 6) == 4:
                         # Per M68k manual, this is always a 32-bit operation
                         size = FP_DATA_SCREGISTER
                         source, extra_source = self.fp_decode_effective_address(
@@ -2261,7 +2261,7 @@ class M68000(Architecture):
                         if (extra >> 13) & 1:
                             source, dest = dest, source
 
-                    elif (sub_fp_operation_code & 0x6) == 6:
+                    elif (sub_fp_operation_code & 6) == 6:
                         # TODO: Consider matching hardware enforced constraints on mode field,
                         #       direction field, register list, and effective address combinations
 

--- a/__init__.py
+++ b/__init__.py
@@ -286,8 +286,7 @@ def m64k_extended_bytes2float(raw_bytes):
             if result_10_exp >= sys.float_info.max_10_exp:
                 result = float('inf')
 
-    # NOTE: Python currently ignores setting 'nan' negative. Serendipitously this matches the
-    #       behavior specified in the m68k manual.
+    # TODO: Python currently ignores setting 'nan' negative
     return float((-1)**sign * result)
 
 

--- a/__init__.py
+++ b/__init__.py
@@ -37,7 +37,7 @@ from binaryninja.binaryview import BinaryView
 from binaryninja.plugin import PluginCommand
 from binaryninja.interaction import AddressField, ChoiceField, get_form_input
 from binaryninja.types import Symbol
-from binaryninja.log import log_error, log_warn
+from binaryninja.log import log_error
 from binaryninja.enums import (Endianness, BranchType, InstructionTextTokenType,
         LowLevelILOperation, LowLevelILFlagCondition, FlagRole, SegmentFlag,
         ImplicitRegisterExtend, SymbolType)
@@ -254,7 +254,7 @@ FP_SizeSuffix = [
 ]
 
 
-# Converts a m64k IEEE 754 64-bit extended precision formatted bytes to a float
+# Converts a m64k IEEE 754 64-bit extended precision formatted bytes object to a float
 # NOTE: This function does NOT attempt to preserve the precision of the extended formatted float
 #       but only converts it into a standard float for display purposes, etc
 def m64k_extended_bytes2float(raw_bytes):
@@ -380,7 +380,7 @@ class FP_OpRegisterDirect(OpRegisterDirect):
         return None
 
     def get_address_il(self, il):
-        return None
+        return il.unimplemented()
 
     def get_source_il(self, il):
         return il.reg(self.size, self.reg)
@@ -526,7 +526,7 @@ class FP_OpRegisterMovemList:
         return None
 
     def get_address_il(self, il):
-        return None
+        return il.unimplemented()
 
     def get_source_il(self, il):
         return [il.reg(self.size, reg) for reg in self.regs]
@@ -566,7 +566,7 @@ class FP_OpSCRegisterMovemList:
         return None
 
     def get_address_il(self, il):
-        return None
+        return il.unimplemented()
 
     def get_source_il(self, il):
         return [il.reg(self.size, reg) for reg in self.regs]
@@ -1153,13 +1153,13 @@ class FP_OpImmediate:
         return None
 
     def get_address_il(self, il):
-        return None
+        return il.unimplemented()
 
     def get_source_il(self, il):
         return il.const(self.size, self.value)
 
     def get_dest_il(self, il, value, flags=0):
-        return None
+        return il.unimplemented()
 
 
 # condition mapping to LLIL flag conditions
@@ -2208,7 +2208,6 @@ class M68000(Architecture):
                             elif instr_sig == 0x38:
                                 instr = 'fcmp'
                             elif instr_sig == 0x3a:
-                                # TODO: Consider removing 'dest' for readability
                                 instr = 'ftst'
 
                         # Handle single and double precision rounding variants

--- a/__init__.py
+++ b/__init__.py
@@ -1728,7 +1728,8 @@ class M68000(Architecture):
                 # TODO
                 style = (instruction >> 8) & 0x7
                 instr = 'bf'+BitfieldStyle[style]
-                length = 4
+                dest, extra_dest = self.decode_effective_address(instruction >> 3, instruction, data[4:], SIZE_LONG)
+                length = 4+extra_dest
             else:
                 # shift/rotate
                 size = (instruction >> 6) & 3
@@ -1749,8 +1750,15 @@ class M68000(Architecture):
                     instr += 'r'
                 length = 2
         elif operation_code == 0xf:
-            if instruction & 0xff20 == 0xf420:
+            if instruction & 0xff20 == 0xf400:
+                instr = 'cinv'
+                length = 2
+            elif instruction & 0xff20 == 0xf420:
                 instr = 'cpush'
+                length = 2
+            elif instruction & 0xffe0 == 0xf500:
+                # MC68*040 variant
+                instr = 'pflush'
                 length = 2
             elif instruction & 0xff80 == 0xff80:
                 instruction = 'illFF'
@@ -2869,6 +2877,12 @@ class M68000(Architecture):
             # TODO
             il.append(il.unimplemented())
         elif instr == 'cpush':
+            # TODO
+            il.append(il.unimplemented())
+        elif instr == 'cinv':
+            # TODO
+            il.append(il.unimplemented())
+        elif instr == 'pflush':
             # TODO
             il.append(il.unimplemented())
         elif instr in ('bhi', 'bls', 'bcc', 'bcs', 'bne', 'beq', 'bvc', 'bvs',


### PR DESCRIPTION
At a high-level these changes add M68040 floating point disassembly (not lifting) support.  This doesn't add support for every floating point instruction, but just the instructions contained in my target binaries.

Support for disassembling the 'cinv' and 'pflush' instructions was also added.

Unfortunately, the changes are more intrusive than I would have liked. To be able to share the existing logic in 'decode_effective_address()' with the floating point logic, I had to modify its API to take a size in bytes.  But on the positive side that code can now be shared (and not duplicated).

I also updated the IL methods of the new floating point operand classes, but it is not tested. It won't be needed until proper support for lifting of the floating point instructions is added. Every attempt has been made, though, to test the new disassembly logic. The accuracy of the disassembly was verified using GCC's m68k cross-toolchain.

A few other considerations I'd like to point out:
- These changes were only tested using M68040 binaries. I did not regression test the other architecture variants
- I did not test the changes for strict Python 2 compatibility
- If/when the plug-in changes are accepted, should consider updating 'plugin.json' as required